### PR TITLE
ansible: Deploy nomad jobs using ansible

### DIFF
--- a/ansible/group_vars/all.yml.sample
+++ b/ansible/group_vars/all.yml.sample
@@ -2,3 +2,8 @@ ansible_user: CHANGEME
 nomad_datacenter_name: "aperture"
 nomad_server_bootstrap_expect: 3
 consul_generated_encrypt_key: CHANGEME
+
+nomad_jobs:
+- traefik
+- dcufm
+- user-vms/distro

--- a/ansible/roles/run-nomad/tasks/main.yaml
+++ b/ansible/roles/run-nomad/tasks/main.yaml
@@ -1,0 +1,12 @@
+---
+
+# TODO: Add Nomad namespaces. 
+
+- name: Run {{ item }} Nomad Job
+  community.general.nomad_job:
+    host: "{{ lookup('ansible.builtin.env', 'NOMAD_ADDR')}}"
+    token: "{{ lookup('ansible.builtin.env', 'NOMAD_TOKEN')}}"
+    state: present
+    content: "{{ lookup('file', '../jobs/' - task - ''.hcl') }}"
+  with_items:
+  - "{{ groups['nomad_jobs']}}"


### PR DESCRIPTION
This is an untested change because I don't have the same environment as Redbrick, but I think it would be beneficial to deploy the jobs using Ansible. This means that it can be automated in the future.

One drawback of this approach is that we don't plan ahead of time, but that should be done as part of a pull request anyways.