### PR TITLE
ansible/templates: Enable Nomad Telemetry

### DIFF
--- a/ansible/templates/nomad-base.hcl.j2
+++ b/ansible/templates/nomad-base.hcl.j2
@@ -8,3 +8,11 @@ advertise {
   rpc  = "{{ ansible_host }}"
   serf = "{{ ansible_host }}"
 }
+
+telemetry {
+  collection_interval        = "1s"
+  disable_hostname           = true
+  prometheus_metrics         = true
+  publish_allocation_metrics = true
+  publish_node_metrics       = true
+}


### PR DESCRIPTION
Enable Telemetry with prometheus metrics so that Nomad metrics can be scraped and alerts can be created if there's an issue.