### PR TITLE
Add job for a nova-timetable user project

### DIFF
--- a/jobs/traefik.hcl
+++ b/jobs/traefik.hcl
@@ -24,7 +24,7 @@ job "traefik" {
     task "traefik" {
       driver = "docker"
       config {
-        image = "traefik:2.8"
+        image = "traefik"
         network_mode = "host"
         
         volumes = [

--- a/jobs/user-projects/general/nova-timetable.hcl
+++ b/jobs/user-projects/general/nova-timetable.hcl
@@ -1,0 +1,40 @@
+job "nova-timetable" {
+  datacenters = ["aperture"]
+
+  type = "service"
+
+  group "nova-timetable" {
+    count = 1
+
+    network {
+      port "http" {
+        to = 80
+      }
+    }
+
+    service {
+      port = "http"
+      name = "nova-timetable"
+      check {
+        type = "http"
+        path = "/"
+        interval = "10s"
+        timeout = "2s"
+      }
+
+      tags = [
+        "traefik.enable=true",
+        "traefik.http.routers.nova-timetable.rule=Host(`timetable.redbrick.dcu.ie`)",
+        "traefik.http.routers.nova-timetable.tls=true",
+      ]
+    }
+
+    task "python-application" {
+      driver = "docker"
+      config {
+        image = "novanai/timetable-sync"
+        ports = ["http"]
+      }
+    }
+  }
+}

--- a/jobs/user-projects/general/nova-timetable.hcl
+++ b/jobs/user-projects/general/nova-timetable.hcl
@@ -15,17 +15,12 @@ job "nova-timetable" {
     service {
       port = "http"
       name = "nova-timetable"
-      check {
-        type = "http"
-        path = "/"
-        interval = "10s"
-        timeout = "2s"
-      }
 
       tags = [
         "traefik.enable=true",
         "traefik.http.routers.nova-timetable.rule=Host(`timetable.redbrick.dcu.ie`)",
-        "traefik.http.routers.nova-timetable.tls=true",
+        "traefik.http.routers.nova-timetable.entrypoints=web,websecure",
+        "traefik.http.routers.nova-timetable.tls.certresolver=lets-encrypt",
       ]
     }
 

--- a/jobs/user-projects/general/nova-timetable.hcl
+++ b/jobs/user-projects/general/nova-timetable.hcl
@@ -15,6 +15,12 @@ job "nova-timetable" {
     service {
       port = "http"
       name = "nova-timetable"
+      check {
+        type = "http"
+        path = "/healthcheck"
+        interval = "10s"
+        timeout = "2s"
+      }
 
       tags = [
         "traefik.enable=true",


### PR DESCRIPTION
This file directory structure can also be used for 4th year projects (user-projects/(third/fourth)-year-project)

I can't validate this, but checkout this branch on one of the hosts and run `nomad job validate <path>` to ensure the config is okay, followed by `nomad job plan <path>` to plan it. Run the job at that point using the check-id. Once you're happy that it runs, return to the master branch and merge this PR.

nova@redbrick.dcu.ie requested this to be deployed.

A DNS entry will need to be made before planning to ensure that the cert can be generated by traefik.