### PR TITLE
Add redis task to nova-timetable job

### DIFF
--- a/jobs/user-projects/general/nova-timetable.hcl
+++ b/jobs/user-projects/general/nova-timetable.hcl
@@ -10,11 +10,16 @@ job "nova-timetable" {
       port "http" {
         to = 80
       }
+
+      port "db" {
+        to = 6379
+      }
     }
 
     service {
-      port = "http"
       name = "nova-timetable"
+      port = "http"
+
       check {
         type = "http"
         path = "/healthcheck"
@@ -32,9 +37,23 @@ job "nova-timetable" {
 
     task "python-application" {
       driver = "docker"
+
+      env {
+        REDIS_ADDRESS = "${NOMAD_ADDR_db}"
+      }
+
       config {
         image = "novanai/timetable-sync"
         ports = ["http"]
+      }
+    }
+
+    task "redis-db" {
+      driver = "docker"
+
+      config {
+        image = "redis:latest"
+        ports = ["db"]
       }
     }
   }


### PR DESCRIPTION
This PR is done in coordination with https://github.com/novanai/timetable-sync/pull/1 to add redis to the nova-timetable job