### PR TITLE
add ingress node pool

### DIFF
--- a/cluster-config/README.md
+++ b/cluster-config/README.md
@@ -1,0 +1,5 @@
+# Nomad Cluster Configuration
+
+This directory contains configuration relating to the configuration of the cluster including:
+- node pools
+- agent config

--- a/cluster-config/README.md
+++ b/cluster-config/README.md
@@ -3,3 +3,9 @@
 This directory contains configuration relating to the configuration of the cluster including:
 - node pools
 - agent config
+
+## Node Pools
+
+[Node pools](https://developer.hashicorp.com/nomad/docs/concepts/node-pools) are a way to group nodes together into logical groups which jobs can target that can be used to enforce where allocations are placed.
+
+e.g. [`ingress-pool.hcl`](./ingress-pool.hcl) is a node pool that is used for ingress nodes such as the [bastion-vm](https://docs.redbrick.dcu.ie/aperture/bastion-vm/). Any jobs that are defined to use `node_pool = "ingress"` such as `traefik.hcl` and `gate-proxy.hcl` will only be assigned to one of the nodes in the `ingress` node pool (i.e. the [bastion VM](https://docs.redbrick.dcu.ie/aperture/bastion-vm/))

--- a/cluster-config/ingress-pool.hcl
+++ b/cluster-config/ingress-pool.hcl
@@ -1,0 +1,3 @@
+node_pool "ingress" {
+  description = "Nodes for ingress to aperture. e.g. bastion-vm"
+}

--- a/jobs/games/gate-proxy.hcl
+++ b/jobs/games/gate-proxy.hcl
@@ -1,14 +1,9 @@
-job "mc-router" {
+job "gate-proxy" {
   datacenters = ["aperture"]
-
+  node_pool = "ingress"
   type = "service"
 
-  constraint {
-    attribute = "${attr.unique.hostname}"
-    value = "bastion-vm"
-  }
-
-  group "mc-router" {
+  group "gate-proxy" {
     count = 1
 
     network {
@@ -27,7 +22,7 @@ job "mc-router" {
       }
     }
 
-    task "webserver" {
+    task "gate-proxy" {
       driver = "docker"
 
       config {
@@ -47,9 +42,11 @@ job "mc-router" {
 config:
   bind: 0.0.0.0:4501
 
+  forwarding:
+    mode: legacy
+
   lite:
     enabled: true
-
     routes:
       - host: fugitives.rb.dcu.ie
         backend: fugitives-mc.service.consul:25566

--- a/jobs/traefik.hcl
+++ b/jobs/traefik.hcl
@@ -1,11 +1,7 @@
 job "traefik" {
   datacenters = ["aperture"]
+  node_pool = "ingress"
   type        = "service"
-
-  constraint {
-    attribute = "${attr.unique.hostname}"
-    value = "bastion-vm"
-  }
 
   group "traefik" {
     network {


### PR DESCRIPTION
adds the `ingress` node pool, mainly for the bastion vm and adds it to the relevant jobs