### PR TITLE
add hedgedoc job

### DIFF
--- a/jobs/services/hedgedoc-backup.hcl
+++ b/jobs/services/hedgedoc-backup.hcl
@@ -1,0 +1,50 @@
+job "hedgedoc-backup" {
+  datacenters = ["aperture"]
+  type        = "batch"
+
+  periodic {
+    crons            = ["0 */3 * * * *"]
+    prohibit_overlap = true
+  }
+
+  group "db-backup" {
+    task "postgres-backup" {
+      driver = "raw_exec"
+
+      config {
+        command = "/bin/bash"
+        args    = ["local/script.sh"]
+      }
+
+      template {
+        data = <<EOH
+#!/bin/bash
+
+file=/storage/backups/nomad/postgres/hedgedoc/postgresql-hedgedoc-$(date +%Y-%m-%d_%H-%M-%S).sql
+
+mkdir -p /storage/backups/nomad/postgres/hedgedoc
+
+alloc_id=$(nomad job status hedgedoc | grep running | tail -n 1 | cut -d " " -f 1)
+
+job_name=$(echo ${NOMAD_JOB_NAME} | cut -d "/" -f 1)
+
+nomad alloc exec -task hedgedoc-db $alloc_id pg_dumpall -U {{ key "hedgedoc/db/user" }} > "${file}"
+
+find /storage/backups/nomad/postgres/hedgedoc/postgresql-hedgedoc* -ctime +3 -exec rm {} \; || true
+
+if [ -s "$file" ]; then # check if file exists and is not empty
+  echo "Backup successful"
+  exit 0
+else
+  rm $file
+  curl -H "Content-Type: application/json" -d \
+  '{"content": "<@&585512338728419341> `PostgreSQL` backup for **'"${job_name}"'** has just **FAILED**\nFile name: `'"$file"'`\nDate: `'"$(TZ=Europe/Dublin date)"'`\nTurn off this script with `nomad job stop '"${job_name}"'` \n\n## Remember to restart this backup job when fixed!!!"}' \
+  {{ key "postgres/webhook/discord" }}
+fi
+EOH
+        destination = "local/script.sh"
+      }
+    }
+  }
+}
+

--- a/jobs/services/hedgedoc.hcl
+++ b/jobs/services/hedgedoc.hcl
@@ -1,0 +1,115 @@
+job "hedgedoc" {
+  datacenters = ["aperture"]
+
+  type = "service"
+
+  group "web" {
+    network {
+    # mode = "bridge"
+      port "http" {
+        to = 3000
+      }
+
+      port "db" {
+        to = 5432
+      }
+    }
+
+    service {
+      name = "hedgedoc"
+      port = "http"
+
+      check {
+        type     = "http"
+        path     = "/"
+        interval = "10s"
+        timeout  = "2s"
+      }
+
+      tags = [
+        "traefik.frontend.headers.STSSeconds=63072000",
+        "traefik.frontend.headers.browserXSSFilter=true",
+        "traefik.frontend.headers.contentTypeNosniff=true",
+        "traefik.frontend.headers.customResponseHeaders=alt-svc:h2=l3sb47bzhpbelafss42pspxzqo3tipuk6bg7nnbacxdfbz7ao6semtyd.onion:443; ma=2592000",
+        "traefik.enable=true",
+        "traefik.port=${NOMAD_PORT_http}",
+        "traefik.http.routers.md.rule=Host(`md.redbrick.dcu.ie`,`md.rb.dcu.ie`)",
+        "traefik.http.routers.md.tls=true",
+        "traefik.http.routers.md.tls.certresolver=lets-encrypt",
+      ]
+    }
+
+    task "app" {
+      driver = "docker"
+
+      constraint {
+        attribute = "${attr.unique.hostname}"
+        value = "chell"
+      }
+
+      config {
+        image = "quay.io/hedgedoc/hedgedoc:1.6.0"
+        ports = ["http"]
+      }
+
+      template {
+        data        = <<EOH
+CMD_IMAGE_UPLOAD_TYPE    = "imgur"
+CMD_IMGUR_CLIENTID       = "{{ key "hedgedoc/imgur/clientid" }}"
+CMD_IMGUR_CLIENTSECRET   = "{{ key "hedgedoc/imgur/clientsecret" }}"
+CMD_DB_URL               = "postgres://{{ key "hedgedoc/db/user" }}:{{ key "hedgedoc/db/password" }}@{{ env "NOMAD_ADDR_db" }}/{{ key "hedgedoc/db/name" }}"
+CMD_ALLOW_FREEURL        = "false"
+CMD_DEFAULT_PERMISSION   = "private"
+CMD_DOMAIN               = "md.redbrick.dcu.ie"
+CMD_ALLOW_ORIGIN         = ["md.redbrick.dcu.ie", "md.rb.dcu.ie"]
+CMD_HSTS_PRELOAD         = "true"
+CMD_USE_CDN              = "true"
+CMD_PROTOCOL_USESSL      = "true"
+CMD_URL_ADDPORT          = "false"
+CMD_ALLOW_EMAIL_REGISTER = "false"
+CMD_ALLOW_ANONYMOUS      = "false"
+CMD_EMAIL                = "false"
+CMD_LDAP_URL             = "{{ key "hedgedoc/ldap/url" }}"
+CMD_LDAP_SEARCHBASE      = "ou=accounts,o=redbrick"
+CMD_LDAP_SEARCHFILTER    = "{{`(uid={{username}})`}}"
+CMD_LDAP_PROVIDERNAME    = "Redbrick"
+CMD_LDAP_USERIDFIELD     = "uidNumber"
+CMD_LDAP_USERNAMEFIELD   = "uid"
+CMD_ALLOW_GRAVATAR       = "true"
+CMD_SESSION_SECRET       = "{{ key "hedgedoc/session/secret" }}"
+CMD_LOG_LEVEL           = "debug"
+EOH
+        destination = "local/.env"
+        env         = true
+      }
+    }
+
+    task "hedgedoc-db" {
+      driver = "docker"
+
+      constraint {
+        attribute = "${attr.unique.hostname}"
+        value = "chell"
+      }
+
+      config {
+        image = "postgres:9.6-alpine"
+        ports = ["db"]
+
+        volumes = [
+            "/opt/postgres/hedgedoc:/var/lib/postgresql/data"
+        ]
+      }
+
+      template {
+        data        = <<EOH
+POSTGRES_PASSWORD={{ key "hedgedoc/db/password" }}
+POSTGRES_USER={{ key "hedgedoc/db/user" }}
+POSTGRES_NAME={{ key "hedgedoc/db/name" }}
+EOH
+        destination = "local/db.env"
+        env         = true
+      }
+    }
+  }
+}


### PR DESCRIPTION
A few notes for this one:
- this has been upgraded from `hackmdio/hackmd:1.3.0` on zeus
- currently running `hedgedoc/hedgedoc:1.6.0`
- Upgrading to hedgedoc >= 1.7.0 requires more migrations so this will be done to a later time
- this job is constrained to `chell`, this is because mounting a db to an NFS mount is extremely unwise. This will be revisited later with CSI
- `CMD_LDAP_USERNAMEFIELD` has been set meaning usernames are shown in the UI as opposed to uuid number

***Do not merge until I add the backup script!!!***