### PR TITLE
privatebin: add paste.redbrick

### DIFF
--- a/jobs/services/privatebin.hcl
+++ b/jobs/services/privatebin.hcl
@@ -25,7 +25,7 @@ job "privatebin" {
 
       tags = [
         "traefik.enable=true",
-        "traefik.http.routers.privatebin.rule=Host(`paste.rb.dcu.ie`)",
+        "traefik.http.routers.privatebin.rule=Host(`paste.rb.dcu.ie`) || Host(`paste.redbrick.dcu.ie`)",
         "traefik.http.routers.privatebin.entrypoints=web,websecure",
         "traefik.http.routers.privatebin.tls.certresolver=lets-encrypt",
       ]


### PR DESCRIPTION
Now that the [old pastebin is gone](https://github.com/redbrick/nix-configs/pull/117), we can point its domain to the new service