### PR TITLE
update ldap secret perms

### DIFF
--- a/jobs/services/api.hcl
+++ b/jobs/services/api.hcl
@@ -70,6 +70,7 @@ EOH
 
     template {
         destination = "local/ldap.secret"
+        perms       = "600"
         data = "{{ key \"api/ldap/secret\" }}" # this is necessary as the secret has no EOF
       }
 

--- a/jobs/services/brickbot.hcl
+++ b/jobs/services/brickbot.hcl
@@ -22,6 +22,7 @@ job "brickbot2" {
 
       template {
         destination = "local/ldap.secret"
+        perms       = "600"
         data = "{{ key \"api/ldap/secret\" }}" # this is necessary as the secret has no EOF
       }
 


### PR DESCRIPTION
updates the perms of `ldap.secret` to a `chmod 600`

Prevents this warning:
```
Warning: Password file /etc/ldap.secret is publicly readable/writeable
```

Not too crucial but still better to follow best practices