### PR TITLE
jobs: update traefik rule for hosts following latest traefik standard

### DIFF
--- a/jobs/dcusr.hcl
+++ b/jobs/dcusr.hcl
@@ -25,7 +25,7 @@ job "dcusr" {
 
       tags = [
         "traefik.enable=true",
-        "traefik.http.routers.dcusr.rule=Host(`solarracing.rb.dcu.ie`,`solarracing.ie`,`www.solarracing.ie`)",
+        "traefik.http.routers.dcusr.rule=Host(`solarracing.rb.dcu.ie`) || Host(`solarracing.ie`) || Host(`www.solarracing.ie`)",
         "traefik.http.routers.dcusr.entrypoints=web,websecure",
         "traefik.http.routers.dcusr.tls.certresolver=lets-encrypt",
       ]

--- a/jobs/nginx/ams-amikon.hcl
+++ b/jobs/nginx/ams-amikon.hcl
@@ -27,7 +27,7 @@ job "ams-amikon" {
       }
       tags = [
         "traefik.enable=true",
-        "traefik.http.routers.ams-amikon.rule=Host(`amikon.me`,`www.amikon.me`)",
+        "traefik.http.routers.ams-amikon.rule=Host(`amikon.me`) || Host(`www.amikon.me`)",
         "traefik.http.routers.ams-amikon.entrypoints=web,websecure",
         "traefik.http.routers.ams-amikon.tls.certresolver=lets-encrypt",
         "traefik.http.routers.ams-amikon.middlewares=www-redirect",

--- a/jobs/services/hedgedoc.hcl
+++ b/jobs/services/hedgedoc.hcl
@@ -33,7 +33,7 @@ job "hedgedoc" {
         "traefik.frontend.headers.customResponseHeaders=alt-svc:h2=l3sb47bzhpbelafss42pspxzqo3tipuk6bg7nnbacxdfbz7ao6semtyd.onion:443; ma=2592000",
         "traefik.enable=true",
         "traefik.port=${NOMAD_PORT_http}",
-        "traefik.http.routers.md.rule=Host(`md.redbrick.dcu.ie`,`md.rb.dcu.ie`)",
+        "traefik.http.routers.md.rule=Host(`md.redbrick.dcu.ie`) || Host(`md.rb.dcu.ie`)",
         "traefik.http.routers.md.tls=true",
         "traefik.http.routers.md.tls.certresolver=lets-encrypt",
       ]


### PR DESCRIPTION
traefik changed their host rules naming convention
Let's fix that!