### PR TITLE
Update nova timetable-sync job

### DIFF
--- a/jobs/user-projects/general/nova-timetable.hcl
+++ b/jobs/user-projects/general/nova-timetable.hcl
@@ -1,16 +1,11 @@
 job "nova-timetable" {
   datacenters = ["aperture"]
-
-  type = "service"
+  type        = "service"
 
   group "nova-timetable" {
     count = 1
 
     network {
-      port "http" {
-        to = 80
-      }
-
       port "db" {
         to = 6379
       }
@@ -34,21 +29,21 @@ job "nova-timetable" {
 
       service {
         name = "nova-timetable-frontend"
-        port = "http"
+        port = "frontend"
 
         check {
-          type = "http"
-          path = "/"
+          type     = "http"
+          path     = "/"
           interval = "10s"
-          timeout = "2s"
+          timeout  = "2s"
         }
 
         tags = [
           "traefik.enable=true",
+          "traefik.port=${NOMAD_PORT_frontend}",
           "traefik.http.routers.nova-timetable-frontend.rule=Host(`timetable.redbrick.dcu.ie`)",
           "traefik.http.routers.nova-timetable-frontend.entrypoints=web,websecure",
           "traefik.http.routers.nova-timetable-frontend.tls.certresolver=lets-encrypt",
-          "traefik.http.services.nova-timetable-frontend.loadbalancer.server.port=3000"
         ]
       }
     }
@@ -67,21 +62,21 @@ job "nova-timetable" {
 
       service {
         name = "nova-timetable-backend"
-        port = "http"
+        port = "backend"
 
         check {
-          type = "http"
-          path = "/api/healthcheck"
+          type     = "http"
+          path     = "/api/healthcheck"
           interval = "10s"
-          timeout = "2s"
+          timeout  = "2s"
         }
 
         tags = [
           "traefik.enable=true",
+          "traefik.port=${NOMAD_PORT_backend}",
           "traefik.http.routers.nova-timetable-backend.rule=Host(`timetable.redbrick.dcu.ie`) && PathPrefix(`/api`)",
           "traefik.http.routers.nova-timetable-backend.entrypoints=web,websecure",
           "traefik.http.routers.nova-timetable-backend.tls.certresolver=lets-encrypt",
-          "traefik.http.services.nova-timetable-backend.loadbalancer.server.port=4000"
         ]
       }
     }

--- a/jobs/user-projects/general/nova-timetable.hcl
+++ b/jobs/user-projects/general/nova-timetable.hcl
@@ -14,28 +14,46 @@ job "nova-timetable" {
       port "db" {
         to = 6379
       }
-    }
 
-    service {
-      name = "nova-timetable"
-      port = "http"
-
-      check {
-        type = "http"
-        path = "/healthcheck"
-        interval = "10s"
-        timeout = "2s"
+      port "frontend" {
+        to = 3000
       }
 
-      tags = [
-        "traefik.enable=true",
-        "traefik.http.routers.nova-timetable.rule=Host(`timetable.redbrick.dcu.ie`)",
-        "traefik.http.routers.nova-timetable.entrypoints=web,websecure",
-        "traefik.http.routers.nova-timetable.tls.certresolver=lets-encrypt",
-      ]
+      port "backend" {
+        to = 4000
+      }
     }
 
-    task "python-application" {
+    task "frontend" {
+      driver = "docker"
+
+      config {
+        image = "ghcr.io/novanai/timetable-sync-frontend:latest"
+        ports = ["frontend"]
+      }
+
+      service {
+        name = "nova-timetable-frontend"
+        port = "http"
+
+        check {
+          type = "http"
+          path = "/"
+          interval = "10s"
+          timeout = "2s"
+        }
+
+        tags = [
+          "traefik.enable=true",
+          "traefik.http.routers.nova-timetable-frontend.rule=Host(`timetable.redbrick.dcu.ie`)",
+          "traefik.http.routers.nova-timetable-frontend.entrypoints=web,websecure",
+          "traefik.http.routers.nova-timetable-frontend.tls.certresolver=lets-encrypt",
+          "traefik.http.services.nova-timetable-frontend.loadbalancer.server.port=3000"
+        ]
+      }
+    }
+
+    task "backend" {
       driver = "docker"
 
       env {
@@ -43,8 +61,28 @@ job "nova-timetable" {
       }
 
       config {
-        image = "novanai/timetable-sync"
-        ports = ["http"]
+        image = "ghcr.io/novanai/timetable-sync-backend:latest"
+        ports = ["backend"]
+      }
+
+      service {
+        name = "nova-timetable-backend"
+        port = "http"
+
+        check {
+          type = "http"
+          path = "/api/healthcheck"
+          interval = "10s"
+          timeout = "2s"
+        }
+
+        tags = [
+          "traefik.enable=true",
+          "traefik.http.routers.nova-timetable-backend.rule=Host(`timetable.redbrick.dcu.ie`) && PathPrefix(`/api`)",
+          "traefik.http.routers.nova-timetable-backend.entrypoints=web,websecure",
+          "traefik.http.routers.nova-timetable-backend.tls.certresolver=lets-encrypt",
+          "traefik.http.services.nova-timetable-backend.loadbalancer.server.port=4000"
+        ]
       }
     }
 


### PR DESCRIPTION
Update the nomad job to support [timetable-sync v2.1.0](https://github.com/novanai/timetable-sync/releases/tag/v2.1.0). Not entirely sure it's correct but I followed the nomad docs so I hope it's okay!