### PR TITLE
Add cns support to nova-timetable job

### DIFF
--- a/jobs/user-projects/general/nova-timetable.hcl
+++ b/jobs/user-projects/general/nova-timetable.hcl
@@ -62,8 +62,7 @@ job "nova-timetable" {
       env {
         BACKEND_PORT = "${NOMAD_PORT_backend}"
         REDIS_ADDRESS = "${NOMAD_ADDR_redis}"
-        CNS_HOST = "clubsandsocs.jakefarrell.ie"
-        CNS_PORT = "443"
+        CNS_ADDRESS = "https://clubsandsocs.jakefarrell.ie"
       }
 
       config {
@@ -140,6 +139,7 @@ POSTGRES_PASSWORD={{ key "user-projects/nova/db/password" }}
 POSTGRES_DB={{ key "user-projects/nova/db/name" }}
 POSTGRES_HOST={{ env "NOMAD_IP_db" }}
 POSTGRES_PORT={{ env "NOMAD_HOST_PORT_db" }}
+CNS_ADDRESS="https://clubsandsocs.jakefarrell.ie"
 EOH
         destination = "local/.env"
         env         = true

--- a/jobs/user-projects/general/nova-timetable.hcl
+++ b/jobs/user-projects/general/nova-timetable.hcl
@@ -14,6 +14,10 @@ job "nova-timetable" {
         to = 5432
       }
 
+      port "cns" {
+        to = 2000
+      }
+
       port "frontend" {
         to = 3000
       }
@@ -23,8 +27,25 @@ job "nova-timetable" {
       }
     }
 
+    task "cns" {
+      driver = "docker"
+
+      env {
+        PORT = "${NOMAD_PORT_cns}"
+      }
+
+      config {
+        image = "ghcr.io/cheeselad/clubsandsocs-api:latest"
+        ports = ["cns"]
+      }
+    }
+
     task "frontend" {
       driver = "docker"
+
+      env {
+        PORT = "${NOMAD_PORT_frontend}"
+      }
 
       config {
         image = "ghcr.io/novanai/timetable-sync-frontend:latest"
@@ -56,7 +77,10 @@ job "nova-timetable" {
       driver = "docker"
 
       env {
+        BACKEND_PORT = "${NOMAD_PORT_backend}"
         REDIS_ADDRESS = "${NOMAD_ADDR_redis}"
+        CNS_HOST = "${NOMAD_IP_cns}"
+        CNS_PORT = "${NOMAD_PORT_cns}"
       }
 
       config {

--- a/jobs/user-projects/general/nova-timetable.hcl
+++ b/jobs/user-projects/general/nova-timetable.hcl
@@ -14,29 +14,12 @@ job "nova-timetable" {
         to = 5432
       }
 
-      port "cns" {
-        to = 2000
-      }
-
       port "frontend" {
         to = 3000
       }
 
       port "backend" {
         to = 4000
-      }
-    }
-
-    task "cns" {
-      driver = "docker"
-
-      env {
-        PORT = "${NOMAD_PORT_cns}"
-      }
-
-      config {
-        image = "ghcr.io/cheeselad/clubsandsocs-api:latest"
-        ports = ["cns"]
       }
     }
 
@@ -79,8 +62,8 @@ job "nova-timetable" {
       env {
         BACKEND_PORT = "${NOMAD_PORT_backend}"
         REDIS_ADDRESS = "${NOMAD_ADDR_redis}"
-        CNS_HOST = "${NOMAD_IP_cns}"
-        CNS_PORT = "${NOMAD_PORT_cns}"
+        CNS_HOST = "clubsandsocs.jakefarrell.ie"
+        CNS_PORT = "443"
       }
 
       config {


### PR DESCRIPTION
Adds support for the clubs & societies calendar.
Requires https://github.com/CheeseLad/clubsandsocs-api/pull/4 to be merged and released.