### PR TITLE
ansible/nomad: enable bridge hairpin mode

### DIFF
--- a/ansible/templates/nomad-client.hcl
+++ b/ansible/templates/nomad-client.hcl
@@ -1,5 +1,11 @@
 client {
   enabled = true
+  # for minecraft modpack zip bombing allowance
+  artifact {
+    decompression_size_limit       = "0"
+    decompression_file_count_limit = 12000
+  }
+  bridge_network_hairpin_mode = true
 }
 
 plugin "raw_exec" {


### PR DESCRIPTION
Adds, hairpin mode to the the bridge network mode. This makes connecting different tasks on the same host much easier.

See here: https://developer.hashicorp.com/nomad/docs/configuration/client#bridge_network_hairpin_mode