### PR TITLE
blockbot: remove unused env variable

### DIFF
--- a/jobs/webgroup/blockbot.hcl
+++ b/jobs/webgroup/blockbot.hcl
@@ -21,6 +21,7 @@ job "blockbot" {
       template {
         data = <<EOF
 TOKEN={{ key "blockbot/discord/token" }}
+DEBUG= # empty means false
 EOF
         destination = "local/.env"
         env = true

--- a/jobs/webgroup/blockbot.hcl
+++ b/jobs/webgroup/blockbot.hcl
@@ -21,7 +21,6 @@ job "blockbot" {
       template {
         data = <<EOF
 TOKEN={{ key "blockbot/discord/token" }}
-DEBUG=false
 EOF
         destination = "local/.env"
         env = true


### PR DESCRIPTION
this doesnt need to exist, as by default debug is false, adding this option is not necessary