### PR TITLE
Mail auth rate limit

### DIFF
--- a/jobs/services/mail/mailserver.hcl
+++ b/jobs/services/mail/mailserver.hcl
@@ -144,8 +144,6 @@ smtpd_sender_restrictions =
   reject_unlisted_sender,
   reject_unauth_pipelining,
   reject_sender_login_mismatch,
-  warn_if_reject,
-  reject_unverified_sender
 
 # Rate limit outgoing mail to prevent spam (100/day)
 smtpd_client_message_rate_limit = 100

--- a/jobs/services/mail/mailserver.hcl
+++ b/jobs/services/mail/mailserver.hcl
@@ -149,6 +149,7 @@ smtpd_sender_restrictions =
 
 # Rate limit outgoing mail to prevent spam (100/day)
 smtpd_client_message_rate_limit = 100
+smtpd_client_auth_rate_limit = 100
 anvil_rate_time_unit = 1d
 
 # This file is so that aliases resolve correctly


### PR DESCRIPTION
Adds authentication rate limiting to postfix config of 100 requests per day per client. Also removes pointless entries in sender restrictions, which should reduce log spam.