### PR TITLE
Addition of Blocklist to Mail + More strict rules on incoming mail

### DIFF
--- a/jobs/monitoring/mail-watch.hcl
+++ b/jobs/monitoring/mail-watch.hcl
@@ -79,20 +79,25 @@ def main():
     prev = read_prev()
 
     while True:
-      try:
-        cur = get_top()
-        # Normalize and sort lines for comparison
-        cur_norm = "\n".join(sorted(line.rstrip() for line in cur.splitlines() if line.strip()))
-      except subprocess.CalledProcessError as e:
-        print(f"Command failed, will retry:\n{e.output}", file=sys.stderr)
-        time.sleep(INTERVAL_SECONDS)
-        continue
+      cur = get_top()
 
+      # Preserve command order for deciding whether the top count exceeds threshold.
+      cur_lines = [line.rstrip() for line in cur.splitlines() if line.strip()]
 
-      if int(cur_norm.split("\n")[0].split(" ")[0]) >= 1000:
-        if cur_norm != prev:
+      # Sort only for state comparison, if ordering should not matter there.
+      cur_norm = "\n".join(sorted(cur_lines))
+
+      if cur_lines:
+        try:
+          top_count = int(cur_lines[0].split()[0])
+        except (IndexError, ValueError):
+          print(f"Unexpected command output: {cur_lines[0]!r}", file=sys.stderr)
+          time.sleep(INTERVAL_SECONDS)
+          continue
+
+        if top_count >= 1000 and cur_norm != prev:
           try:
-            post_webhook(cur if cur.strip() else "(no sasl_username matches)")
+            post_webhook(cur)
             write_prev(cur)
             prev = cur_norm
           except Exception as e:

--- a/jobs/monitoring/mail-watch.hcl
+++ b/jobs/monitoring/mail-watch.hcl
@@ -27,12 +27,11 @@ import os
 import subprocess
 import sys
 import time
-import json
 import requests
 
 LOG_PATH = "/var/log/mail/mail.log"
 TOP_N = int(os.environ.get("TOP_N", "30"))
-WEBHOOK_URL = "{{key "mail/monitor/webhookurl"}}"
+WEBHOOK_URL = "{{key "mail/monitor/webhookurl" }}"
 STATE_FILE = os.environ.get("STATE_FILE", "/alloc/top_sasl_prev.txt")
 INTERVAL_SECONDS = int(os.environ.get("INTERVAL_SECONDS", "60"))
 
@@ -89,13 +88,15 @@ def main():
         time.sleep(INTERVAL_SECONDS)
         continue
 
-      if cur_norm != prev:
-        try:
-          post_webhook(cur if cur.strip() else "(no sasl_username matches)")
-          write_prev(cur)
-          prev = cur_norm
-        except Exception as e:
-          print(f"Webhook failed, will retry next interval: {e}", file=sys.stderr)
+
+      if int(cur_norm.split("\n")[0].split(" ")[0]) >= 1000:
+        if cur_norm != prev:
+          try:
+            post_webhook(cur if cur.strip() else "(no sasl_username matches)")
+            write_prev(cur)
+            prev = cur_norm
+          except Exception as e:
+            print(f"Webhook failed, will retry next interval: {e}", file=sys.stderr)
 
       time.sleep(INTERVAL_SECONDS)
 

--- a/jobs/services/mail/aliases
+++ b/jobs/services/mail/aliases
@@ -462,3 +462,11 @@ dme3@redbrick.dcu.ie	dme4@redbrick.dcu.ie
 garyod2@redbrick.dcu.ie	gary@redbrick.dcu.ie
 haus17@redbrick.dcu.ie	haus@redbrick.dcu.ie
 nadned@redbrick.dcu.ie	damnson@redbrick.dcu.ie
+
+# Esports aliases
+ahri-dcuesports@redbrick.dcu.ie	 dcuesportssoc@gmail.com
+bastion-dcuesports@redbrick.dcu.ie	 dcuesportssoc@gmail.com
+clove-dcuesports@redbrick.dcu.ie	 dcuesportssoc@gmail.com
+draven-dcuesports@redbrick.dcu.ie	 dcuesportssoc@gmail.com
+echo-dcuesports@redbrick.dcu.ie	 dcuesportssoc@gmail.com
+supernova-dcuesports@redbrick.dcu.ie	 dcuesportssoc@gmail.com

--- a/jobs/services/mail/mailserver.env
+++ b/jobs/services/mail/mailserver.env
@@ -126,7 +126,7 @@ ENABLE_IMAP=1
 # Enables ClamAV, and anti-virus scanner.
 #   1   => Enabled
 # **0** => Disabled
-ENABLE_CLAMAV=0
+ENABLE_CLAMAV=1
 
 # Add the value of this ENV as a prefix to the mail subject when spam is detected.
 # NOTE: This subject prefix may be redundant (by default spam is delivered to a junk folder).
@@ -180,7 +180,7 @@ RSPAMD_HFILTER=1
 # Can be used to control the score when the HFILTER_HOSTNAME_UNKNOWN symbol applies. A higher score is more punishing. Setting it to 15 is equivalent to rejecting the email when the check fails.
 #
 # Default: 6
-RSPAMD_HFILTER_HOSTNAME_UNKNOWN_SCORE=6
+RSPAMD_HFILTER_HOSTNAME_UNKNOWN_SCORE=8
 
 # Can be used to enable or disable the (still experimental) neural module.
 #
@@ -226,7 +226,7 @@ ENABLE_MANAGESIEVE=1
 # drop => Drop the connection immediately with a 521 SMTP reply. Repeat this test the next time the client connects.
 # ignore => Ignore the failure of this test. Allow other tests to complete. Repeat this test the next time the client connects. This option is useful for testing and collecting statistics without blocking mail.
 # NOTE: Change this at some point plz
-POSTSCREEN_ACTION=ignore
+POSTSCREEN_ACTION=enforce
 
 # empty => all daemons start
 # 1 => only launch postfix smtp
@@ -348,7 +348,7 @@ LOGROTATE_COUNT=12
 #
 # - **0** => Disabled
 # - 1 => Enabled
-POSTFIX_REJECT_UNKNOWN_CLIENT_HOSTNAME=0
+POSTFIX_REJECT_UNKNOWN_CLIENT_HOSTNAME=1
 
 # Choose TCP/IP protocols for postfix to use
 # **all** => All possible protocols.
@@ -508,7 +508,7 @@ DOVECOT_PASS_ATTRS=userPassword=password
 # -----------------------------------------------
 # --- Postgrey Section --------------------------
 # -----------------------------------------------
-ENABLE_POSTGREY=0
+ENABLE_POSTGREY=1
 # greylist for N seconds
 POSTGREY_DELAY=30
 # delete entries older than N days since the last time that they have been seen
@@ -516,7 +516,7 @@ POSTGREY_MAX_AGE=35
 # response when a mail is greylisted
 POSTGREY_TEXT="Delayed by Postgrey"
 # whitelist host after N successful deliveries (N=0 to disable whitelisting)
-POSTGREY_AUTO_WHITELIST_CLIENTS=5
+POSTGREY_AUTO_WHITELIST_CLIENTS=0
 
 # -----------------------------------------------
 # --- SASL Section ------------------------------

--- a/jobs/services/mail/mailserver.env
+++ b/jobs/services/mail/mailserver.env
@@ -211,7 +211,7 @@ ENABLE_DNSBL=1
 #    cap_add:
 #      - NET_ADMIN
 # Otherwise, `nftables` won't be able to ban IPs.
-ENABLE_FAIL2BAN=1
+ENABLE_FAIL2BAN=0
 
 # Fail2Ban blocktype
 # drop   => drop packet (send NO reply)
@@ -239,7 +239,9 @@ SMTP_ONLY=
 # custom => Enables custom certificates
 # manual => Let's you manually specify locations of your SSL certificates for non-standard cases
 # self-signed => Enables self-signed certificates
-SSL_TYPE=letsencrypt
+SSL_TYPE=manual
+SSL_CERT_PATH=/etc/docker-mailserver/ssl/redbrick.dcu.ie/fullchain.pem
+SSL_KEY_PATH=/etc/docker-mailserver/ssl/redbrick.dcu.ie/privkey.pem
 
 # Set how many days a virusmail will stay on the server before being deleted
 # empty => 7 days

--- a/jobs/services/mail/mailserver.hcl
+++ b/jobs/services/mail/mailserver.hcl
@@ -96,6 +96,7 @@ job "mailserver" {
 
           "local/postfix-main.cf:/tmp/docker-mailserver/postfix-main.cf",
           "local/transport:/etc/postfix/transport",
+          "local/sender_blocklist:/etc/postfix/sender_blocklist:ro",
           "local/sender_whitelist:/etc/postfix/sender_whitelist:ro",
           "local/postfix-sender-login.pcre:/etc/postfix/postfix-sender-login.pcre:ro",
           "local/10-auth.conf:/etc/dovecot/conf.d/10-auth.conf:ro",
@@ -136,6 +137,7 @@ smtpd_sender_login_maps = pcre:/etc/postfix/postfix-sender-login.pcre
 # Allow only mailman senders (Mailman) to send as list addresses
 # and allow authenticated users/mynetworks before rejecting mismatches.
 smtpd_sender_restrictions =
+  check_sender_access texthash:/etc/postfix/sender_blocklist,
   check_sender_access texthash:/etc/postfix/sender_whitelist,
   permit_mynetworks,
   permit_sasl_authenticated,
@@ -152,6 +154,13 @@ anvil_rate_time_unit = 1d
 
 # This file is so that aliases resolve correctly
 virtual_alias_maps = texthash:/tmp/docker-mailserver/aliases
+EOH
+      }
+
+      template {
+        destination = "local/sender_blocklist"
+        data        = <<EOH
+ {{ key "mail/postfix/sender_blocklist" }}
 EOH
       }
 

--- a/jobs/services/mail/mailserver.hcl
+++ b/jobs/services/mail/mailserver.hcl
@@ -121,6 +121,52 @@ job "mailserver" {
       }
     }
 
+    task "configure-mail-egress" {
+      driver = "raw_exec"
+
+      lifecycle {
+        hook    = "prestart"
+        sidecar = false
+      }
+
+      config {
+        command = "/bin/bash"
+        args = [
+          "-ec",
+          <<-EOF
+            MAIL_IP="136.206.16.50"
+            MAIL_INTERFACE="eno1"
+            DOCKER_SUBNET="172.17.0.0/16"
+
+            ip -4 address show dev "$MAIL_INTERFACE" |
+              grep -qE "[[:space:]]$MAIL_IP/" ||
+              ip address add "$MAIL_IP/32" dev "$MAIL_INTERFACE"
+
+            while iptables -t nat -C POSTROUTING \
+              -s "$DOCKER_SUBNET" \
+              -p tcp --dport 25 \
+              -j SNAT --to-source "$MAIL_IP" 2>/dev/null
+            do
+              iptables -t nat -D POSTROUTING \
+                -s "$DOCKER_SUBNET" \
+                -p tcp --dport 25 \
+                -j SNAT --to-source "$MAIL_IP"
+            done
+
+            iptables -t nat -I POSTROUTING 1 \
+              -s "$DOCKER_SUBNET" \
+              -p tcp --dport 25 \
+              -j SNAT --to-source "$MAIL_IP"
+          EOF
+        ]
+      }
+
+      resources {
+        cpu    = 50
+        memory = 32
+      }
+    }
+
     task "mail-server" {
       driver = "docker"
 
@@ -151,7 +197,6 @@ job "mailserver" {
 
           "local/postfix-main.cf:/tmp/docker-mailserver/postfix-main.cf",
           "local/transport:/etc/postfix/transport",
-
           # Add a blocklist and whitelist for senders to control who can send to us and who we will accept mail from.
           "local/sender_blocklist:/etc/postfix/sender_blocklist:ro",
           "local/sender_whitelist:/etc/postfix/sender_whitelist:ro",
@@ -300,6 +345,10 @@ EOH
         destination = "local/99-proxy-protocol.conf"
         data        = <<EOH
 # Enable PROXY protocol support for mail traffic proxied by Traefik.
+# This is additive: it does not replace the main Dovecot config.
+
+# Trust only Traefik/Nomad-side proxy source networks.
+# 10.20.0.2 appeared in Dovecot logs as the current proxy source.
 haproxy_trusted_networks = 127.0.0.1/32 10.10.0.0/16 10.20.0.0/16 136.206.16.0/24
 
 service imap-login {

--- a/jobs/services/mail/mailserver.hcl
+++ b/jobs/services/mail/mailserver.hcl
@@ -1,7 +1,11 @@
 job "mailserver" {
   datacenters = ["aperture"]
   type        = "service"
-  node_pool   = "ingress"
+
+  constraint {
+    attribute = "${meta.ingress_vip_node}"
+    value     = "1"
+  }
 
   meta {
     tld    = "redbrick.dcu.ie"
@@ -16,36 +20,76 @@ job "mailserver" {
       }
 
       port "smtp" {
-        static = 25
+        to = 25
       }
 
       port "submissions" {
-        static = 465
+        to = 465
       }
 
       port "submission" {
-        static = 587
+        to = 587
       }
 
       port "imap" {
-        static = 143
+        to = 143
       }
 
       port "imaps" {
-        static = 993
+        to = 993
       }
 
       port "pop3" {
-        static = 110
+        to = 110
       }
 
       port "pop3s" {
-        static = 995
+        to = 995
       }
 
       port "managesieve" {
-        static = 4190
+        to = 4190
       }
+    }
+
+    service {
+      name = "mailserver-smtp"
+      port = "smtp"
+    }
+
+    service {
+      name = "mailserver-submissions"
+      port = "submissions"
+    }
+
+    service {
+      name = "mailserver-submission"
+      port = "submission"
+    }
+
+    service {
+      name = "mailserver-imap"
+      port = "imap"
+    }
+
+    service {
+      name = "mailserver-imaps"
+      port = "imaps"
+    }
+
+    service {
+      name = "mailserver-pop3"
+      port = "pop3"
+    }
+
+    service {
+      name = "mailserver-pop3s"
+      port = "pop3s"
+    }
+
+    service {
+      name = "mailserver-managesieve"
+      port = "managesieve"
     }
 
     task "whoami" {
@@ -57,7 +101,7 @@ job "mailserver" {
       }
 
       service {
-        name = "whoami"
+        name = "mail-http"
         port = "http"
 
         check {
@@ -71,8 +115,8 @@ job "mailserver" {
           "traefik.enable=true",
           "traefik.port=${NOMAD_PORT_http}",
           "traefik.http.routers.mail-http.rule=Host(`${NOMAD_META_domain}`)",
-          "traefik.http.routers.mail-http.entrypoints=web,websecure",
-          "traefik.http.routers.mail-http.tls.certresolver=lets-encrypt",
+          "traefik.http.routers.mail-http.entrypoints=websecure",
+          "traefik.http.routers.mail-http.tls=true",
         ]
       }
     }
@@ -81,8 +125,19 @@ job "mailserver" {
       driver = "docker"
 
       config {
-        image = "ghcr.io/docker-mailserver/docker-mailserver:latest"
-        ports = ["smtp", "submissions", "submission", "imap", "imaps", "pop3", "pop3s", "managesieve"]
+        image    = "ghcr.io/docker-mailserver/docker-mailserver:latest"
+        hostname = "mail.redbrick.dcu.ie"
+
+        ports = [
+          "smtp",
+          "submissions",
+          "submission",
+          "imap",
+          "imaps",
+          "pop3",
+          "pop3s",
+          "managesieve"
+        ]
 
         volumes = [
           # mount mailserver dirs
@@ -91,20 +146,22 @@ job "mailserver" {
           "/storage/nomad/mail/logs/:/var/log/mail/",
           "/storage/nomad/mail/config/:/tmp/docker-mailserver/",
 
-          # acme.json in read-only mode so certs can be generated
-          "/storage/nomad/traefik/acme/acme.json:/etc/letsencrypt/acme.json:ro",
+          # Use extracted wildcard PEM certs, not Traefik ACME JSON.
+          "/storage/nomad/traefik/certs/redbrick.dcu.ie:/etc/docker-mailserver/ssl/redbrick.dcu.ie:ro",
 
           "local/postfix-main.cf:/tmp/docker-mailserver/postfix-main.cf",
           "local/transport:/etc/postfix/transport",
+
+          # Add a blocklist and whitelist for senders to control who can send to us and who we will accept mail from.
           "local/sender_blocklist:/etc/postfix/sender_blocklist:ro",
           "local/sender_whitelist:/etc/postfix/sender_whitelist:ro",
           "local/postfix-sender-login.pcre:/etc/postfix/postfix-sender-login.pcre:ro",
           "local/10-auth.conf:/etc/dovecot/conf.d/10-auth.conf:ro",
           "local/aliases:/tmp/docker-mailserver/aliases:ro",
           "local/sasl_access:/etc/postfix/sasl_access:ro",
+          "local/99-proxy-protocol.conf:/etc/dovecot/conf.d/99-proxy-protocol.conf:ro",
 
           "/etc/localtime:/etc/localtime:ro",
-
           "/storage/home:/home/:ro",
 
           # Mount persistant master.cf to keep smtpd_client_restrictions settings across restarts
@@ -236,6 +293,40 @@ EOH
         destination = "local/sasl_access"
         data        = <<EOH
 {{ key "mail/postfix/sasl_access" }}
+EOH
+      }
+
+      template {
+        destination = "local/99-proxy-protocol.conf"
+        data        = <<EOH
+# Enable PROXY protocol support for mail traffic proxied by Traefik.
+haproxy_trusted_networks = 127.0.0.1/32 10.10.0.0/16 10.20.0.0/16 136.206.16.0/24
+
+service imap-login {
+  inet_listener imap {
+    haproxy = yes
+  }
+
+  inet_listener imaps {
+    haproxy = yes
+  }
+}
+
+service pop3-login {
+  inet_listener pop3 {
+    haproxy = yes
+  }
+
+  inet_listener pop3s {
+    haproxy = yes
+  }
+}
+
+service managesieve-login {
+  inet_listener sieve {
+    haproxy = yes
+  }
+}
 EOH
       }
 

--- a/jobs/services/mail/mailserver.hcl
+++ b/jobs/services/mail/mailserver.hcl
@@ -217,7 +217,7 @@ EOH
       template {
         destination = "local/sender_blocklist"
         data        = <<EOH
- {{ key "mail/postfix/sender_blocklist" }}
+{{ key "mail/postfix/sender_blocklist" }}
 EOH
       }
 


### PR DESCRIPTION
This Pull Request adds a blocklist to mail (So the admins can specifically block incoming mail from a particular service) and also increases/enables some features to reduce spam to mail.

The blocklist is in `mail/postfix/sender_blocklist` and uses the following format. 

For example:
```
spammer@example.com REJECT Blocked sender address
.bad-tld REJECT Blocked sender TLD
```

Changes to Mail rules:

* Enabled ClamAV antivirus
* Increased the spam filter score for unknown hostnames (`RSPAMD_HFILTER_HOSTNAME_UNKNOWN_SCORE`) from 6 to 8, making spam detection stricter.
* Changed `POSTSCREEN_ACTION` from `ignore` to `enforce`, so failed postscreen tests now actively block connections instead of just logging them.
* Enabled Postfix rejection of clients with unknown hostnames by setting `POSTFIX_REJECT_UNKNOWN_CLIENT_HOSTNAME=1`.
* Enabled Postgrey (greylisting) by setting `ENABLE_POSTGREY=1`, and disabled auto-whitelisting of clients after successful deliveries (`POSTGREY_AUTO_WHITELIST_CLIENTS=0`).