### PR TITLE
Changed nginx version from nginx:alpine to nginx:1.30.2-alpine

### DIFF
--- a/jobs/services/mail/roundcube.hcl
+++ b/jobs/services/mail/roundcube.hcl
@@ -36,7 +36,6 @@ job "roundcube" {
         "traefik.enable=true",
         "traefik.http.routers.roundcube.rule=Host(`${NOMAD_META_domain}`)",
         "traefik.http.routers.roundcube.entrypoints=web,websecure",
-        "traefik.http.routers.roundcube.tls.certresolver=lets-encrypt",
       ]
     }
 
@@ -44,7 +43,7 @@ job "roundcube" {
       driver = "docker"
 
       config {
-        image    = "nginx:alpine"
+        image    = "nginx:1.30.2-alpine"
         ports    = ["http"]
         hostname = "${NOMAD_META_domain}"
         volumes = [
@@ -158,7 +157,7 @@ $config['managesieve_conn_options'] = [
 # show forwarding option on the UI
 $config['managesieve_forward'] = 1;
 EOH
-  }
+      }
     }
 
     task "roundcube-db" {

--- a/jobs/services/webtree.hcl
+++ b/jobs/services/webtree.hcl
@@ -35,7 +35,7 @@ job "webtree" {
     task "webtree-nginx" {
       driver = "docker"
       config {
-        image = "nginx:alpine"
+        image = "nginx:1.30.2-alpine"
         ports = ["http"]
         volumes = [
           "/storage/webtree:/webtree",

--- a/jobs/services/wiki/mediawiki.hcl
+++ b/jobs/services/wiki/mediawiki.hcl
@@ -38,7 +38,6 @@ job "mediawiki" {
         "traefik.port=${NOMAD_PORT_http}",
         "traefik.http.routers.rbwiki.rule=Host(`${NOMAD_META_domain}`) || Host(`wiki.rb.dcu.ie`)",
         "traefik.http.routers.rbwiki.entrypoints=web,websecure",
-        "traefik.http.routers.rbwiki.tls.certresolver=rb",
         "traefik.http.routers.rbwiki.middlewares=rbwiki-redirect-root, rbwiki-redirect-mw",
         "traefik.http.middlewares.rbwiki-redirect-root.redirectregex.regex=^https://wiki\\.redbrick\\.dcu\\.ie/?$",
         "traefik.http.middlewares.rbwiki-redirect-root.redirectregex.replacement=https://wiki.redbrick.dcu.ie/Main_Page",
@@ -50,7 +49,7 @@ job "mediawiki" {
     task "rbwiki-nginx" {
       driver = "docker"
       config {
-        image = "nginx:alpine"
+        image = "nginx:1.30.2-alpine"
         ports = ["http"]
         volumes = [
           "local/nginx.conf:/etc/nginx/nginx.conf",
@@ -146,8 +145,8 @@ EOH
 
       # php.ini file because php is ass and won't let you update this in LocalSettings.php
       template {
-        destination = "local/php.ini" 
-        data = <<EOH
+        destination = "local/php.ini"
+        data        = <<EOH
 post_max_size = 64M
 upload_max_filesize = 50M
 EOH

--- a/jobs/socs/mps-thecollegeview.hcl
+++ b/jobs/socs/mps-thecollegeview.hcl
@@ -40,7 +40,6 @@ job "mps-thecollegeview" {
         "traefik.enable=true",
         "traefik.http.routers.tcv.rule=Host(`${NOMAD_META_domain}`)",
         "traefik.http.routers.tcv.entrypoints=web,websecure",
-        "traefik.http.routers.tcv.tls.certresolver=lets-encrypt",
       ]
     }
 
@@ -49,7 +48,7 @@ job "mps-thecollegeview" {
       driver = "docker"
 
       config {
-        image = "nginx:alpine"
+        image = "nginx:1.30.2-alpine"
         ports = ["http"]
         volumes = [
           "local/nginx.conf:/etc/nginx/nginx.conf",

--- a/jobs/socs/style-thelook.hcl
+++ b/jobs/socs/style-thelook.hcl
@@ -40,7 +40,6 @@ job "style-thelook" {
         "traefik.enable=true",
         "traefik.http.routers.thelook.rule=Host(`${NOMAD_META_domain}`) || Host(`style.redbrick.dcu.ie`)",
         "traefik.http.routers.thelook.entrypoints=web,websecure",
-        "traefik.http.routers.thelook.tls.certresolver=lets-encrypt",
       ]
     }
 
@@ -49,7 +48,7 @@ job "style-thelook" {
       driver = "docker"
 
       config {
-        image = "nginx:alpine"
+        image = "nginx:1.30.2-alpine"
         ports = ["http"]
         volumes = [
           "local/nginx.conf:/etc/nginx/nginx.conf",


### PR DESCRIPTION
This Pull Request updates some jobs from `nginx:alpine` to `nginx:1.30.2-alpine` to utilize a patched version addressing the "nginx-poolslip" exploit.
