### PR TITLE
Disabled phpinfo and phpversion functions for webtree

### DIFF
--- a/jobs/services/webtree.hcl
+++ b/jobs/services/webtree.hcl
@@ -239,7 +239,7 @@ EOH
 ; Mostly to improve performance and compatability with legacy webtree sites
 
 expose_php = Off
-disable_functions = "phpinfo, phpversion"
+disable_functions = "phpinfo, phpversion, php_uname"
 default_charset = "UTF-8"
 date.timezone = "Europe/Dublin"
 

--- a/jobs/services/webtree.hcl
+++ b/jobs/services/webtree.hcl
@@ -239,6 +239,7 @@ EOH
 ; Mostly to improve performance and compatability with legacy webtree sites
 
 expose_php = Off
+disable_functions = "phpinfo, phpversion"
 default_charset = "UTF-8"
 date.timezone = "Europe/Dublin"
 


### PR DESCRIPTION
This Pull Request disables the `phpinfo()` function and hides the PHP version to prevent any potential information disclosure vulnerabilities.